### PR TITLE
bumping gradle build tools version to 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.0-beta1'
+    classpath 'com.android.tools.build:gradle:1.3.1'
     classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
     classpath 'com.novoda:bintray-release:0.2.10'
   }


### PR DESCRIPTION
Hi,

Thanks for the great sample app with annotation processing and code generation!

In this PR I'm updating Gradle Build Tools to the newer version.
Change was suggested by Android Studio after opening the project.

Regards,
Piotr
